### PR TITLE
Updates README with correct TM Bundle path

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ TextMate 2 bundle: Adds new line at EOL if missing in current document when savi
 
 ## Installation
 
-- Clone the git repo to  `~/Library/Application Support/Avian/Bundles`
+- Clone the git repo to  `~/Library/Application Support/Textmate/Bundles`
 - Relaunch TextMate 2
 
 ## Customization using `.tm_properties`


### PR DESCRIPTION
Textmate now loads every Bundle from `~/Library/Application Support/Textmate`
and will suggest you move your bundles from the old location.

Signed-off-by: Frédéric De Villamil <fdevillamil@synthesio.com>